### PR TITLE
Add Sections 181-216

### DIFF
--- a/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/yaml/Action.java
+++ b/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/yaml/Action.java
@@ -1,18 +1,45 @@
 package ch.bbw.fabbwled.lands.book.yaml;
 
 import ch.bbw.fabbwled.lands.book.SectionId;
+import ch.bbw.fabbwled.lands.exception.FabledTechnicalException;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface Action {
-    record TextAction(String text) implements Action {}
+    void simpleVerify();
 
-    record IfAction(Condition condition, List<Action> then, Optional<List<Action>> else_) implements Action {}
+    record TextAction(String text) implements Action {
+        @Override
+        public void simpleVerify() {}
+    }
 
-    record TurnToAction(SectionId sectionId) implements Action {}
+    record IfAction(Condition condition, List<Action> then, Optional<List<Action>> else_) implements Action {
+        @Override
+        public void simpleVerify() {
+            then.forEach(Action::simpleVerify);
+            else_.ifPresent(else_ -> else_.forEach(Action::simpleVerify));
+        }
+    }
+
+    record TurnToAction(SectionId sectionId) implements Action {
+        @Override
+        public void simpleVerify() {}
+    }
 
     record Choice(List<SingleChoice> choices) implements Action {
+        @Override
+        public void simpleVerify() {
+            if (choices.isEmpty()) {
+                throw new FabledTechnicalException("Found choice with no choices, this doesn't make sense.");
+            }
+            if (choices.size() == 1) {
+                throw new FabledTechnicalException("Choice action only has a single choice, don't use a choice.");
+            }
+
+            choices.forEach(choice -> choice.actions.forEach(Action::simpleVerify));
+        }
+
         record SingleChoice(String text, List<Action> actions) {}
     }
 }

--- a/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/yaml/YamlSection.java
+++ b/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/yaml/YamlSection.java
@@ -4,4 +4,8 @@ import ch.bbw.fabbwled.lands.book.SectionId;
 
 import java.util.List;
 
-public record YamlSection(SectionId id, List<Action> actions) {}
+public record YamlSection(SectionId id, List<Action> actions) {
+    public void simpleVerify() {
+        this.actions.forEach(Action::simpleVerify);
+    }
+}

--- a/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/yaml/YamlSectionLoader.java
+++ b/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/yaml/YamlSectionLoader.java
@@ -35,7 +35,9 @@ public class YamlSectionLoader {
             return rawSection.map((section) -> {
                 try {
                     var actions = builder.buildActions(section.content());
-                    return new YamlSection(new SectionId(1, section.number()), actions);
+                    var yamlSection = new YamlSection(new SectionId(1, section.number()), actions);
+                    yamlSection.simpleVerify();
+                    return yamlSection;
                 } catch (FabledTechnicalException e) {
                     throw new FabledTechnicalException("Invalid section: " + section.number(), e);
                 }

--- a/fabbwled-backend/src/test/java/ch/bbw/fabbwled/lands/book/yaml/YamlVerificationTest.java
+++ b/fabbwled-backend/src/test/java/ch/bbw/fabbwled/lands/book/yaml/YamlVerificationTest.java
@@ -1,0 +1,26 @@
+package ch.bbw.fabbwled.lands.book.yaml;
+
+import ch.bbw.fabbwled.lands.book.SectionId;
+import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class YamlVerificationTest implements WithAssertions {
+    @Test
+    void verifyEmptyChoice() {
+        var action = new Action.Choice(List.of());
+
+        assertThatThrownBy(action::simpleVerify).hasMessage("Found choice with no choices, this doesn't make sense.");
+    }
+
+    @Test
+    void verifySingleChoice() {
+        var action = new Action.Choice(List.of(new Action.Choice.SingleChoice(
+                "hello",
+                List.of(new Action.TurnToAction(new SectionId(1, 1)))
+        )));
+
+        assertThatThrownBy(action::simpleVerify).hasMessage("Choice action only has a single choice, don't use a choice.");
+    }
+}


### PR DESCRIPTION
### What?

This PR verifies basic properties about sections. Concretely, we check that every `choice` has at least two elements. If that's not upheld, we error.

### Why?

To avoid mistakes.

### Testing?

I have added two tests that test for errors. The existing YAMLs are a test that ensures that we don't get false positives.

I am planning to add more complex session verification that makes sure that things like "no other action after `turnTo`" are upheld. (basically a compiler reachability analysis, this YAML section stuff is basically a compiler)

### What?

### Why?

### How?

### Testing?

### Screenshots (for frontend changes)

### Anything Else?

[//]: # (for a sample see: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)
