### PR TITLE
#23 Added Openapi spec

### DIFF
--- a/fabbwled-backend/build.gradle
+++ b/fabbwled-backend/build.gradle
@@ -22,6 +22,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/fabbwled-backend/src/main/resources/application.yaml
+++ b/fabbwled-backend/src/main/resources/application.yaml
@@ -21,3 +21,6 @@ spring:
   output:
     ansi:
       enabled: ALWAYS
+springdoc:
+  api-docs:
+    path: "/api-docs"


### PR DESCRIPTION
### What?
Added OpenAPI spec generator and swagger is accessible
### Why?
Good for the frontend developers
### How?
Gradle plugin and path
### Testing?
Start Backend and go to localhost:8080/api-docs to view spec and go to localhost:8080/swagger-ui.html
### Screenshots (for frontend changes)

### Anything Else?
https://github.com/springdoc/springdoc-openapi-gradle-plugin
![image](https://github.com/keykey7/fabbwled/assets/72388742/34a6cf55-4c98-4346-b251-18f60cbdc45b)
https://github.com/keykey7/fabbwled/wiki/OpenAPI-spec
