### PR TITLE
Playable CLI Client

### DIFF
--- a/fabbwled-backend/build.gradle
+++ b/fabbwled-backend/build.gradle
@@ -36,4 +36,5 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+	systemProperty "java.awt.headless", "false"
 }

--- a/fabbwled-backend/build.gradle
+++ b/fabbwled-backend/build.gradle
@@ -11,10 +11,17 @@ java {
     sourceCompatibility = '17'
 }
 
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
+sourceSets {
+    cli {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
     }
+}
+
+configurations {
+    compileOnly.extendsFrom annotationProcessor
+    cliImplementation.extendsFrom testImplementation
+    cliRuntimeOnly.extendsFrom testRuntimeOnly
 }
 
 repositories {
@@ -36,5 +43,4 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
-	systemProperty "java.awt.headless", "false"
 }

--- a/fabbwled-backend/src/cli/java/ch/bbw/fabbwled/lands/CliTestMain.java
+++ b/fabbwled-backend/src/cli/java/ch/bbw/fabbwled/lands/CliTestMain.java
@@ -5,17 +5,13 @@ import ch.bbw.fabbwled.lands.book.SectionId;
 import ch.bbw.fabbwled.lands.controller.PlayerController;
 import ch.bbw.fabbwled.lands.controller.SectionController;
 import ch.bbw.fabbwled.lands.service.PlayerSession;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import javax.swing.*;
-import java.awt.*;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, properties = {"logging.level.ch.bbw.fabbwled=WARN"})
 @ActiveProfiles("test")
@@ -30,11 +26,9 @@ class CliTestMain {
 	@Autowired
 	SectionController sectionController;
 
-	@BeforeAll
-	static void onlyInHeadless() {
-		assumeTrue(!GraphicsEnvironment.isHeadless());
-        assumeTrue(System.getenv("CI") == null);
-	}
+    static {
+        System.setProperty("java.awt.headless", "false");
+    }
 
 	@Test
 	void run() {

--- a/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/SectionDto.java
+++ b/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/SectionDto.java
@@ -8,6 +8,14 @@ package ch.bbw.fabbwled.lands.book;
  */
 public record SectionDto(SectionId id, SectionTicks ticks, SectionNode body) {
 
+	public String asPlainText() {
+		var text = "---------- \033[1m" + id().sectionId() + "\033[22m ";
+		text += ticks().asPlainText();
+		text += "----------\n";
+		text += body().asPlainText();
+		return text;
+	}
+
 	/**
 	 * Section Ticks are checkboxes displayed next to the section number.
 	 * @param total amount of checkboxes
@@ -25,6 +33,14 @@ public record SectionDto(SectionId id, SectionTicks ticks, SectionNode body) {
 
 		public static SectionTicks none() {
 			return new SectionTicks(0, 0);
+		}
+
+		public String asPlainText() {
+			if (total == 0) {
+				return "";
+			}
+			return "☒".repeat(ticked) +
+					"☐".repeat(total - ticked) + " ";
 		}
 	}
 }

--- a/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/SectionNode.java
+++ b/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/SectionNode.java
@@ -76,6 +76,21 @@ public interface SectionNode {
 			return NodeType.CONTAINER;
 		}
 
+		@Override
+		public String asPlainText() {
+			return switch (style) {
+				case NONE -> children()
+						.stream()
+						.map(SectionNode::asPlainText)
+						.collect(Collectors.joining());
+				case DISABLED -> "\033[37m" + children()
+						.stream()
+						.map(SectionNode::asPlainText)
+						.collect(Collectors.joining()) + "\033[39m"; // grey FG
+				case CHOICE -> "\t" + children.get(0).asPlainText() + "\t" + children.get(1).asPlainText() + "\n";
+			};
+		}
+
 		ContainerNode append(SectionNode child) {
 			return new ContainerNode(style, Stream.concat(children.stream(), Stream.of(child)).toList());
 		}
@@ -166,6 +181,11 @@ public interface SectionNode {
 		public NodeType getType() {
 			return NodeType.CLICKABLE;
 		}
+
+		@Override
+		public String asPlainText() {
+			return "\033[4m" + child.asPlainText() + " [" + clickId + "]\033[24m"; // underlined
+		}
 	}
 
 	record SimpleNode(SimpleStyleType style, String text) implements SectionNode {
@@ -187,6 +207,17 @@ public interface SectionNode {
 
 		public static SimpleNode tickbox(boolean active) {
 			return new SimpleNode(SimpleStyleType.TICKBOX, String.valueOf(active));
+		}
+
+		@Override
+		public String asPlainText() {
+			return switch (style) {
+				case NONE -> text;
+				case SECTION -> "\033[1m" + text + "\033[22m"; // bold
+				case ABILITY -> text.toUpperCase();
+				case ITEM -> "\033[3m" + text + "\033[23m"; // italic
+				case TICKBOX -> "true".equals(text) ? "☒" : "☐";
+			};
 		}
 
 		@Override

--- a/fabbwled-backend/src/test/java/ch/bbw/fabbwled/lands/CliTestMain.java
+++ b/fabbwled-backend/src/test/java/ch/bbw/fabbwled/lands/CliTestMain.java
@@ -15,7 +15,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, properties = {"logging.level.ch.bbw.fabbwled=WARN"})
 @ActiveProfiles("test")
@@ -32,7 +32,8 @@ class CliTestMain {
 
 	@BeforeAll
 	static void onlyInHeadless() {
-		assumeFalse(GraphicsEnvironment.isHeadless());
+		assumeTrue(!GraphicsEnvironment.isHeadless());
+        assumeTrue(System.getenv("CI") == null);
 	}
 
 	@Test

--- a/fabbwled-backend/src/test/java/ch/bbw/fabbwled/lands/CliTestMain.java
+++ b/fabbwled-backend/src/test/java/ch/bbw/fabbwled/lands/CliTestMain.java
@@ -1,0 +1,75 @@
+package ch.bbw.fabbwled.lands;
+
+import ch.bbw.fabbwled.lands.book.SectionDto;
+import ch.bbw.fabbwled.lands.book.SectionId;
+import ch.bbw.fabbwled.lands.controller.PlayerController;
+import ch.bbw.fabbwled.lands.controller.SectionController;
+import ch.bbw.fabbwled.lands.service.PlayerSession;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, properties = {"logging.level.ch.bbw.fabbwled=WARN"})
+@ActiveProfiles("test")
+class CliTestMain {
+
+	@Autowired
+	PlayerSession playerSession;
+
+	@Autowired
+	PlayerController playerController;
+
+	@Autowired
+	SectionController sectionController;
+
+	@BeforeAll
+	static void onlyInHeadless() {
+		assumeFalse(GraphicsEnvironment.isHeadless());
+	}
+
+	@Test
+	void run() {
+		playerSession.update(x -> x.withCurrentSection(SectionId.book1(15)));
+		while (true) {
+			var me = playerController.whoami();
+			var section = sectionController.byId(me.currentSection().bookId(), me.currentSection().sectionId());
+			System.out.println(section.asPlainText());
+			var shouldContinue = askForNextAction(me, section);
+			if (!shouldContinue) {
+				break;
+			}
+		}
+	}
+
+	private boolean askForNextAction(PlayerSession.PlayerDto me, SectionDto section) {
+		var validOptions = Stream.concat(section.body().allClickIds().stream().sorted().map(i -> "" + i),
+				Stream.of("stats")).toList();
+		var selectedId = JOptionPane.showOptionDialog(null,
+				"Pick an option",
+				"What to do next",
+				JOptionPane.YES_NO_OPTION,
+				JOptionPane.QUESTION_MESSAGE,
+				null,     //do not use a custom Icon
+				validOptions.toArray(),  //the titles of buttons
+				validOptions.get(0));
+		if (selectedId == JOptionPane.CLOSED_OPTION) {
+			return false;
+		}
+		var action = validOptions.get(selectedId);
+		if (action.equals("stats")) {
+			System.out.println(me.toString()); // not very nice, but it works
+		}
+		else {
+			sectionController.click(new SectionController.SectionClick(Integer.parseInt(action)));
+		}
+		return true;
+	}
+}


### PR DESCRIPTION
### What?
A playable CLI client.
Renders text with a minimum of console styling and presents pickable options as a simple AWT dialog popup.

### Why?
To allow easy testing of sections without a FE.

### How?
Implemented as a junit test (disabled if headless).
The AWT dialog sucks, but stdin is intercepted by Gradle so this is an ugly solution to allow any blocking user interaction during tests. A restful client would have been a more complicated alternative, but doesn't solve the issue of blocking user interaction.
