### PR TITLE
Ser/Deserialize SectionId as a string

### DIFF
--- a/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/SectionId.java
+++ b/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/SectionId.java
@@ -1,9 +1,25 @@
 package ch.bbw.fabbwled.lands.book;
 
+import ch.bbw.fabbwled.lands.exception.FabledBusinessException;
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
 /**
  * @param bookId unique book identifier (1-6)
  * @param sectionId unique section number
  */
+@JsonSerialize(using = SectionId.Serializer.class)
+@JsonDeserialize(using = SectionId.Deserializer.class)
 public record SectionId(int bookId, int sectionId) {
 
 	public SectionId {
@@ -15,7 +31,62 @@ public record SectionId(int bookId, int sectionId) {
 		}
 	}
 
+    public static SectionId parse(String content) {
+        var parts = content.split(":");
+        if (parts.length != 2) {
+            throw new FabledBusinessException("Section ID must be in BOOK:SECTION format");
+        }
+        try {
+            var book = Integer.parseInt(parts[0]);
+            var section = Integer.parseInt(parts[1]);
+            return new SectionId(book, section);
+        } catch (NumberFormatException ex) {
+            throw new FabledBusinessException("Invalid section ID format, must be BOOK:SECTION", ex);
+        }
+    }
+
 	public static SectionId book1(int sectionId) {
 		return new SectionId(1, sectionId);
 	}
+
+    @Override
+    public String toString() {
+        return this.bookId + ":" + this.sectionId;
+    }
+
+    public static class Serializer extends StdSerializer<SectionId> {
+        public Serializer() {
+            this(null);
+        }
+        public Serializer(Class<SectionId> t) {
+            super(t);
+        }
+
+        @Override
+        public void serialize(SectionId value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeString(value.toString());
+        }
+    }
+
+    public static class Deserializer extends StdDeserializer<SectionId> {
+        public Deserializer() {
+            this(null);
+        }
+
+        public Deserializer(Class<?> vc) {
+            super(vc);
+        }
+
+        @Override
+        public SectionId deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+            return SectionId.parse(p.getValueAsString());
+        }
+    }
+
+    public static class SectionIdKeyDeserializer extends KeyDeserializer {
+        @Override
+        public Object deserializeKey(String key, DeserializationContext ctxt) throws IOException {
+            return SectionId.parse(key);
+        }
+    }
 }

--- a/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/service/PlayerSession.java
+++ b/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/service/PlayerSession.java
@@ -7,6 +7,8 @@ import ch.bbw.fabbwled.lands.character.ProfessionEnum;
 import ch.bbw.fabbwled.lands.character.RankEnum;
 import ch.bbw.fabbwled.lands.exception.FabledBusinessException;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.With;
@@ -99,7 +101,9 @@ public class PlayerSession {
                             Character.BaseStatsDto baseStats,
                             List<String> possessions, 
                             ShardSystem shards,
-                            Map<SectionId, Integer> tickBoxes,
+                            @JsonDeserialize(keyUsing = SectionId.SectionIdKeyDeserializer.class)
+                                @JsonSerialize(keyUsing = SectionId.SectionidKeySerializer.class)
+                                Map<SectionId, Integer> tickBoxes,
                             Set<String> codeWords,
                             Set<BlessingEnum> blessings
                             ) {


### PR DESCRIPTION
JSON does not support maps with complex keys. This is why we need to tell jackson that we want to deserialize our map key as a string.

fixes #467

### What?

We use a custom serializer/deserializer to always treat `SectionId` like a string.

### Why?

We want to use `SectionId` in map keys, which need to be strings in JSON.

### How?

Using custom serializers/deserializers.

### Testing?

not yet!

### Screenshots (for frontend changes)

### Anything Else?

[//]: # (for a sample see: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)
