### PR TITLE
sectionId serializer and some webClientTests

### DIFF
--- a/fabbwled-backend/build.gradle
+++ b/fabbwled-backend/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.4.1'
 }
 

--- a/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/SectionId.java
+++ b/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/SectionId.java
@@ -1,5 +1,8 @@
 package ch.bbw.fabbwled.lands.book;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 /**
  * @param bookId unique book identifier (1-6)
  * @param sectionId unique section number
@@ -18,4 +21,15 @@ public record SectionId(int bookId, int sectionId) {
 	public static SectionId book1(int sectionId) {
 		return new SectionId(1, sectionId);
 	}
+
+    @JsonCreator
+    public SectionId(String serialized) {
+        this(Integer.parseInt(serialized.split("-", 2)[0]), Integer.parseInt(serialized.split("-", 2)[1]));
+    }
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return bookId + "-" + sectionId;
+    }
 }

--- a/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/controller/PlayerController.java
+++ b/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/controller/PlayerController.java
@@ -32,7 +32,7 @@ public class PlayerController {
         return characterService.getAllCharacters(bookId);
     }
 
-    @PostMapping()
+    @PostMapping(consumes = "application/json")
     public ResponseEntity<Character.CharacterCreateDto> setCharacter(@RequestBody Character.CharacterCreateDto createdPlayer) {
         playerSession.setInitialCreation(true);
         playerSession.update(player -> {

--- a/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/exception/DefaultErrorHandler.java
+++ b/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/exception/DefaultErrorHandler.java
@@ -1,0 +1,18 @@
+package ch.bbw.fabbwled.lands.exception;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@ControllerAdvice
+public class DefaultErrorHandler {
+
+    @ExceptionHandler
+    @SneakyThrows
+    public void defaultInterceptor(Exception e) {
+        log.warn("exception at application boundary", e);
+        throw e;
+    }
+}

--- a/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/service/PlayerSession.java
+++ b/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/service/PlayerSession.java
@@ -1,14 +1,10 @@
 package ch.bbw.fabbwled.lands.service;
 
 import ch.bbw.fabbwled.lands.book.SectionId;
-import ch.bbw.fabbwled.lands.character.BlessingEnum;
 import ch.bbw.fabbwled.lands.character.Character;
-import ch.bbw.fabbwled.lands.character.ProfessionEnum;
-import ch.bbw.fabbwled.lands.character.RankEnum;
-import ch.bbw.fabbwled.lands.character.Resurrection;
+import ch.bbw.fabbwled.lands.character.*;
 import ch.bbw.fabbwled.lands.exception.FabledBusinessException;
 import lombok.Builder;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.With;
@@ -98,7 +94,7 @@ public class PlayerSession {
                             ProfessionEnum profession,
                             int stamina,
                             String god,
-                            @JsonIgnore int staminaWhenUnwounded,
+                            int staminaWhenUnwounded,
                             Character.BaseStatsDto baseStats,
                             List<String> possessions, 
                             ShardSystem shards,

--- a/fabbwled-backend/src/main/resources/application.yaml
+++ b/fabbwled-backend/src/main/resources/application.yaml
@@ -1,6 +1,7 @@
 logging:
   level:
     ch.bbw.fabbwled: debug
+    org.springframework.web: DEBUG
     root: info
   pattern:
     dateformat: HH:mm:ss

--- a/fabbwled-backend/src/test/java/ch/bbw/fabbwled/lands/controller/PlayerControllerTest.java
+++ b/fabbwled-backend/src/test/java/ch/bbw/fabbwled/lands/controller/PlayerControllerTest.java
@@ -1,0 +1,46 @@
+package ch.bbw.fabbwled.lands.controller;
+
+import ch.bbw.fabbwled.lands.FabledTestBase;
+import ch.bbw.fabbwled.lands.character.Character;
+import ch.bbw.fabbwled.lands.service.PlayerSession;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@AutoConfigureMockMvc
+class PlayerControllerTest extends FabledTestBase {
+
+    @Autowired
+    WebTestClient client;
+
+    @Test
+    void whoami() {
+        client.get()
+                .uri("/api/player")
+                .exchange()
+                .expectStatus()
+                .is2xxSuccessful()
+                .expectBody(PlayerSession.PlayerDto.class);
+    }
+
+    @Test
+    void getAndSetCharacters() {
+        var any = client.get()
+                .uri("/api/player/{bookId}/all", 1)
+                .exchange()
+                .expectStatus()
+                .is2xxSuccessful()
+                .expectBodyList(Character.CharacterCreateDto.class)
+                .value(list -> assertThat(list).isNotEmpty())
+                .returnResult()
+                .getResponseBody()
+                .get(0);
+        client.post()
+                .uri("/api/player")
+                .bodyValue(any)
+                .exchange()
+                .expectStatus()
+                .is2xxSuccessful();
+    }
+}


### PR DESCRIPTION
### What?
- custom JSON serializer/deserializer for `SectionId` to make it usable as a key of a map
- webClient based testing of the controller

### Why?
- becuase of confusing "UTF8 not supported" as in https://github.com/keykey7/fabbwled/issues/467 

### How?
providing a way to make the SectionId object a string (and back).
adding controller tests to prevent issues like these to surface.

fixes https://github.com/keykey7/fabbwled/issues/467 
duplicates to https://github.com/keykey7/fabbwled/pull/530