### PR TITLE
Refactor action building to be sane

### DIFF
--- a/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/yaml/ActionBuilder.java
+++ b/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/yaml/ActionBuilder.java
@@ -5,64 +5,53 @@ import ch.bbw.fabbwled.lands.exception.FabledTechnicalException;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class ActionBuilder {
+
     public List<Action> buildActions(List<RawAction> rawActions) {
         return rawActions.stream().map(this::build).collect(Collectors.toList());
     }
 
     public Action build(RawAction raw) {
-        if (raw.text() != null) {
-            assertNull(raw.if_(), "if", "text");
-            assertNull(raw.then(), "then", "text");
-            assertNull(raw.else_(), "else", "text");
-            assertNull(raw.turnTo(), "turnTo", "text");
-            assertNull(raw.choice(), "choice", "text");
-            assertNull(raw.checkTickBox(), "checkTickBox", "text");
-            assertNull(raw.acquireKeyword(), "acquireKeyword", "text");
-            assertNull(raw.acquirePossession(), "acquirePossession", "text");
-            assertNull(raw.spendShards(), "spendShards", "text");
+        var selectedKind = allActionKinds.stream().filter(actionKind -> actionKind.extractor.apply(raw) != null)
+                .findFirst().orElseThrow(() -> new FabledTechnicalException("no action kind registered for action. you need to add your action to the allActionKinds list in ActionBuilder"));
 
-            return new Action.TextAction(raw.text());
-        }
-
-        if (raw.if_() != null) {
-            if (raw.then() == null) {
-                throw new FabledTechnicalException("`if` action requires a `then`");
+        allActionKinds.forEach(actionKind -> {
+            if (actionKind != selectedKind) {
+                if (actionKind.extractor.apply(raw) != null) {
+                    throw new FabledTechnicalException("Invalid action. Cannot have both " + selectedKind.name + " and " + actionKind.name);
+                }
             }
-            assertNull(raw.turnTo(), "turnTo", "if");
-            assertNull(raw.choice(), "choice", "if");
-            assertNull(raw.acquireKeyword(), "choice", "if");
+        });
 
-            Optional<List<Action>> else_ =
-                    raw.else_() != null ? Optional.of(buildActions(raw.else_())) : Optional.empty();
-
-            return new Action.IfAction(this.buildCondition(raw.if_()), buildActions(raw.then()), else_);
-        }
-
-        if (raw.choice() != null) {
-            assertNull(raw.turnTo(), "turnTo", "choice");
-
-            if (raw.choice().isEmpty()) {
-                throw new FabledTechnicalException("choice must not be empty");
-            }
-
-            var choices = raw.choice().stream().map(choice -> {
-                var actions = buildActions(choice.then());
-
-                return new Action.Choice.SingleChoice(choice.text(), actions);
-            }).collect(Collectors.toList());
-
-            return new Action.Choice(choices);
-        }
-
-        if (raw.turnTo() != null) {
-            return new Action.TurnToAction(new SectionId(1, raw.turnTo()));
-        }
-
-        throw new FabledTechnicalException("Section must have one property");
+        return selectedKind.builder.apply(raw);
     }
+
+    private final List<ActionKind> allActionKinds = List.of(
+            new ActionKind("text", RawAction::text, raw -> new Action.TextAction(raw.text())),
+            new ActionKind("if", RawAction::if_, raw -> {
+                Optional<List<Action>> else_ =
+                        raw.else_() != null ? Optional.of(buildActions(raw.else_())) : Optional.empty();
+
+                return new Action.IfAction(this.buildCondition(raw.if_()), buildActions(raw.then()), else_);
+            }),
+            new ActionKind("choice", RawAction::choice, raw -> {
+                if (raw.choice().isEmpty()) {
+                    throw new FabledTechnicalException("choice must not be empty");
+                }
+
+                var choices = raw.choice().stream().map(choice -> {
+                    var actions = buildActions(choice.then());
+
+                    return new Action.Choice.SingleChoice(choice.text(), actions);
+                }).collect(Collectors.toList());
+
+                return new Action.Choice(choices);
+            }),
+            new ActionKind("turnTo", RawAction::turnTo, raw -> new Action.TurnToAction(new SectionId(1, raw.turnTo())))
+    );
 
     private Condition buildCondition(RawCondition raw) {
         if (raw.hasTitle() != null) {
@@ -86,7 +75,7 @@ public class ActionBuilder {
             return new Condition.NeedsAtLeastShards(raw.needsAtLeastShards());
         }
 
-        if(raw.isTickBoxDone() != null) {
+        if (raw.isTickBoxDone() != null) {
             return new Condition.IsTickBoxDone(raw.isTickBoxDone());
         }
         if (raw.hasPossession() != null) {
@@ -96,10 +85,16 @@ public class ActionBuilder {
         throw new FabledTechnicalException("Condition must have one property");
     }
 
-
     private void assertNull(Object value, String name, String selected) {
         if (value != null) {
             throw new FabledTechnicalException("Invalid action. Cannot have both " + name + " and " + selected);
         }
     }
+
+    record ActionKind(String name, Function<RawAction, Object> extractor, Function<RawAction, Action> builder) {
+    }
+
+
+
+
 }


### PR DESCRIPTION
### What?

Refactors action building to use a registry based approach.

### Why?

This significantly reduces the previous exponential code duplication, making it a lot easier to add new action kinds.

### How?

By using a "registry" of actions, only a single place has to be edited.

### Testing?

All tests still pass.

### Screenshots (for frontend changes)

### Anything Else?

[//]: # (for a sample see: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)
