### PR TITLE
Implement more action kinds

### DIFF
--- a/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/SectionNode.java
+++ b/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/SectionNode.java
@@ -91,7 +91,7 @@ public interface SectionNode {
 			};
 		}
 
-		ContainerNode append(SectionNode child) {
+		public ContainerNode append(SectionNode child) {
 			return new ContainerNode(style, Stream.concat(children.stream(), Stream.of(child)).toList());
 		}
 

--- a/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/yaml/ActionBuilder.java
+++ b/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/yaml/ActionBuilder.java
@@ -50,6 +50,10 @@ public class ActionBuilder {
 
                 return new Action.Choice(choices);
             }),
+            new ActionKind("acquireKeyword", RawAction::acquireKeyword, raw -> new Action.AcquireKeywordAction(raw.acquireKeyword())),
+            new ActionKind("checkTickBox", RawAction::checkTickBox, raw -> new Action.CheckTickBoxAction(raw.checkTickBox())),
+            new ActionKind("acquirePossession", RawAction::acquirePossession, raw -> new Action.AcquirePosessionAction(raw.acquirePossession())),
+            new ActionKind("spendShards", RawAction::spendShards, raw -> new Action.SpendShardsAction(raw.spendShards())),
             new ActionKind("turnTo", RawAction::turnTo, raw -> new Action.TurnToAction(new SectionId(1, raw.turnTo())))
     );
 

--- a/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/yaml/RawAction.java
+++ b/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/book/yaml/RawAction.java
@@ -13,7 +13,7 @@ public record RawAction(String text, @JsonProperty("if") RawCondition if_,
                         List<RawChoice> choice,
                         String acquireKeyword,
                         Integer turnTo,
-                        Boolean checkTickBox,String acquirePossession, String spendShards) {}
+                        Boolean checkTickBox,String acquirePossession, Integer spendShards) {}
 
 
 

--- a/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/service/CharacterService.java
+++ b/fabbwled-backend/src/main/java/ch/bbw/fabbwled/lands/service/CharacterService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @Service
@@ -34,7 +33,7 @@ public class CharacterService {
                             .baseStats(new Character.BaseStatsDto(2, 5, 2, 3, 6, 4))
                             .possessions(List.of("spear", "leather jerkin (Defence +1)", "map"))
                             .shards(new ShardSystem(16))
-                            .tickBoxes(Map.of())
+                            .tickBoxes(new HashMap<>())
                             .codeWords(Collections.emptySet())
                             .blessings(Collections.emptySet())
                             .isResurrectionPossible(false)
@@ -60,7 +59,7 @@ public class CharacterService {
                             .baseStats(new Character.BaseStatsDto(3, 6, 2, 4, 3, 2))
                             .possessions(List.of("battle-axe", "leather jerkin (Defence +1)", "map"))
                             .shards(new ShardSystem(16))
-                            .tickBoxes(Map.of())
+                            .tickBoxes(new HashMap<>())
                             .codeWords(Collections.emptySet())
                             .god("Ebron")
                             .blessings(Collections.emptySet())
@@ -85,7 +84,7 @@ public class CharacterService {
                             .baseStats(new Character.BaseStatsDto(2, 2, 6, 1, 5, 3))
                             .possessions(List.of("staff, leather jerkin (Defence +1), map"))
                             .shards(new ShardSystem(16))
-                            .tickBoxes(Map.of())
+                            .tickBoxes(new HashMap<>())
                             .codeWords(Collections.emptySet())
                             .god("Ebron")
                             .isResurrectionPossible(false)
@@ -112,7 +111,7 @@ public class CharacterService {
                             .possessions(List.of("sword", "leather jerkin (Defence +1)", "map"))
                             .shards(new ShardSystem(16))
                             .god("Ebron")
-                            .tickBoxes(Map.of())
+                            .tickBoxes(new HashMap<>())
                             .codeWords(Collections.emptySet())
                             .blessings(Collections.emptySet())
                             .isResurrectionPossible(false)
@@ -137,7 +136,7 @@ public class CharacterService {
                             .baseStats(new Character.BaseStatsDto(4, 2, 3, 6, 4, 2))
                             .possessions(List.of("mace", "leather jerkin (Defence +1)", "map"))
                             .shards(new ShardSystem(16))
-                            .tickBoxes(Map.of())
+                            .tickBoxes(new HashMap<>())
                             .codeWords(Collections.emptySet())
                             .isResurrectionPossible(false)
                             .blessings(Collections.emptySet())
@@ -162,7 +161,7 @@ public class CharacterService {
                             .baseStats(new Character.BaseStatsDto(6, 3, 4, 3, 2, 4))
                             .possessions(List.of("sword", "leather jerkin (Defence +1)", "map"))
                             .shards(new ShardSystem(16))
-                            .tickBoxes(Map.of())
+                            .tickBoxes(new HashMap<>())
                             .codeWords(Collections.emptySet())
                             .isResurrectionPossible(false)
                             .blessings(Collections.emptySet())

--- a/fabbwled-backend/src/test/java/ch/bbw/fabbwled/lands/service/CharacterServiceTest.java
+++ b/fabbwled-backend/src/test/java/ch/bbw/fabbwled/lands/service/CharacterServiceTest.java
@@ -7,14 +7,13 @@ import ch.bbw.fabbwled.lands.character.ProfessionEnum;
 import ch.bbw.fabbwled.lands.character.RankEnum;
 import ch.bbw.fabbwled.lands.character.Resurrection;
 import ch.bbw.fabbwled.lands.exception.FabledBusinessException;
-import ch.bbw.fabbwled.lands.service.ShardSystem;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @SpringBootTest
 class CharacterServiceTest extends FabledTestBase {
@@ -51,7 +50,7 @@ class CharacterServiceTest extends FabledTestBase {
                 .baseStats(new Character.BaseStatsDto(2, 5, 2, 3, 6, 4))
                 .possessions(List.of("spear", "leather jerkin (Defence +1)", "map"))
                 .shards(new ShardSystem(16))
-                .tickBoxes(Map.of())
+                .tickBoxes(new HashMap<>())
                 .codeWords(Collections.emptySet())
                 .isResurrectionPossible(false)
                 .god("Ebron")
@@ -79,7 +78,7 @@ class CharacterServiceTest extends FabledTestBase {
                 .baseStats(new Character.BaseStatsDto(2, 5, 2, 3, 7, 4))
                 .possessions(List.of("spear", "leather jerkin (Defence +1)", "map"))
                 .shards(new ShardSystem(16))
-                .tickBoxes(Map.of())
+                .tickBoxes(new HashMap<>())
                 .codeWords(Collections.emptySet())
                 .isResurrectionPossible(false)
                 .staminaWhenUnwounded(9)
@@ -108,7 +107,7 @@ class CharacterServiceTest extends FabledTestBase {
                 .baseStats(new Character.BaseStatsDto(2, 5, 2, 3, 6, 4))
                 .possessions(List.of("spear", "leather jerkin (Defence +1)", "map", "sword", "shield", "sword", "shield", "sword", "shield", "sword", "shield", "sword", "shield"))
                 .shards(new ShardSystem(16))
-                .tickBoxes(Map.of())
+                .tickBoxes(new HashMap<>())
                 .codeWords(Collections.emptySet())
                 .isResurrectionPossible(false)
                 .blessings(Collections.emptySet())
@@ -138,7 +137,7 @@ class CharacterServiceTest extends FabledTestBase {
                 .baseStats(new Character.BaseStatsDto(2, 5, 2, 3, 6, 4))
                 .possessions(List.of("spear", "leather jerkin (Defence +1)", "map"))
                 .shards(new ShardSystem(16))
-                .tickBoxes(Map.of())
+                .tickBoxes(new HashMap<>())
                 .codeWords(Collections.emptySet())
                 .staminaWhenUnwounded(9)
                 .god("Ebron")


### PR DESCRIPTION
closes #156

### What?

Implement the `acquireKeyword`, `checkTickBox`, `acquirePossession`, `spendShards` actions fully. To ease and accelerate development these were only half implemented in the raw stage.

### Why?

To be able to actually use them.

### How?

By adding new records to `Action` and building them.

### Testing?

manual testing with printing state before/after and adding these statements to random sections.