### PR TITLE
Don't make JSESSIONID http-only

### DIFF
--- a/fabbwled-backend/src/main/resources/application.yaml
+++ b/fabbwled-backend/src/main/resources/application.yaml
@@ -11,7 +11,7 @@ server:
   servlet:
     session:
       cookie:
-        http-only: true
+        http-only: false
         secure: true
 spring:
   application:


### PR DESCRIPTION
This allows the frontend to manipulate it to implement different save games.

There is no security to be lost.

### What?

Don't make the session ID http only.

### Why?

So the frontend could access it in the future. It is not clear whether this is needed today, but there's no reason not to do this.

### How?

By changing the config

### Testing?

I have no tested it but don't want to
